### PR TITLE
Enable keyboard-only advance after correct answers

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -331,8 +331,14 @@ document.addEventListener('DOMContentLoaded', () => {
     checkAnswerButton.addEventListener('click', checkAnswer);
     speakWordButton.addEventListener('click', speakCurrentWord);
     answerInput.addEventListener('keypress', (event) => {
-        if (event.key === 'Enter' && !checkAnswerButton.disabled) {
-            checkAnswer();
+        if (event.key === 'Enter') {
+            if (!checkAnswerButton.disabled) {
+                checkAnswer();
+            } else if (!startPracticeButton.disabled) {
+                // Allows pressing Enter again after a correct answer to
+                // proceed to the next word without clicking the button
+                startPracticeButton.click();
+            }
         }
     });
 


### PR DESCRIPTION
## Summary
- allow pressing Enter again after a correct answer to start the next word

## Testing
- `node -v`