### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "github-pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Upload static files
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ Enjoy practicing your Chinese!
 ## Continuous Deployment
 
 The site is automatically deployed to GitHub Pages whenever changes are pushed
-to the `main` branch. The workflow lives in `.github/workflows/deploy.yml` and
+to the `master` branch. The workflow lives in `.github/workflows/deploy.yml` and
 uploads the contents of the repository to the GitHub Pages environment.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ Vocabulary lives in the `vocab/` directory (files named `vocab-lesson*.js`). Eac
 The app includes a Service Worker and `manifest.json` so it can be installed on your device. After visiting the page once, it should continue to work without an internet connection.
 
 Enjoy practicing your Chinese!
+
+## Continuous Deployment
+
+The site is automatically deployed to GitHub Pages whenever changes are pushed
+to the `main` branch. The workflow lives in `.github/workflows/deploy.yml` and
+uploads the contents of the repository to the GitHub Pages environment.


### PR DESCRIPTION
## Summary
- deploy static site to GitHub Pages on every push to `main`
- document the continuous deployment workflow in the README

## Testing
- `git status --short`