### PR TITLE
Add repeat failed practice option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You can try the live site at [https://elias-sundqvist.github.io/integrated-chine
   - English → Characters
   - Chinese → Pinyin with tone numbers
 - Randomized questions and score tracking
+- Option to keep practicing only the words you missed
 - Works offline after the first visit
 
 ## Getting Started
@@ -21,6 +22,7 @@ You can try the live site at [https://elias-sundqvist.github.io/integrated-chine
 3. Choose a lesson and practice mode, then click **Start/Next Word**.
 
 The app will display a prompt based on your selected mode. Type your answer and click **Check Answer**. Your score updates as you progress through the vocabulary list.
+After a section is complete, click **Practice Failed** to drill only the words you missed.
 
 ## Adding More Vocabulary
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
                 <option value="chineseToPinyin">Chinese -> Pinyin (tones as numbers)</option>
             </select>
             <button id="start-practice">Start/Next Word</button>
+            <button id="practice-failed" disabled>Practice Failed</button>
         </div>
 
         <div class="practice-area">


### PR DESCRIPTION
## Summary
- add **Practice Failed** button to focus on missed words
- store whole word object for results
- allow `startPractice` to accept a custom list
- re-enable Enter key to trigger the failed practice
- mention new feature in README

## Testing
- `npm test` *(fails: could not find package.json)*